### PR TITLE
Fix screenshots on Android 16 QPR2 / Android 17+ (ScreenCapture rewrite)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 36
     defaultConfig {
         applicationId "com.rayworks.droidcast"
         minSdkVersion 14
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode 131
         versionName "1.2.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/rayworks/droidcast/ScreenCaptorUtils.java
+++ b/app/src/main/java/com/rayworks/droidcast/ScreenCaptorUtils.java
@@ -227,9 +227,11 @@ public final class ScreenCaptorUtils {
     }
 
     /** Wraps a reflectively obtained {@link HardwareBuffer} into a {@link Bitmap}. */
-    @RequiresApi(api = Build.VERSION_CODES.O)
+    @RequiresApi(api = Build.VERSION_CODES.Q)
     private static Bitmap wrapScreenshotBuffer(Object hardwareBufferObj, ColorSpace colorSpace) {
         try (HardwareBuffer hardwareBuffer = (HardwareBuffer) hardwareBufferObj) {
+            if (hardwareBuffer == null)
+                return null;
             return Bitmap.wrapHardwareBuffer(hardwareBuffer, colorSpace);
         }
     }

--- a/app/src/main/java/com/rayworks/droidcast/ScreenCaptorUtils.java
+++ b/app/src/main/java/com/rayworks/droidcast/ScreenCaptorUtils.java
@@ -7,6 +7,7 @@ import android.graphics.Rect;
 import android.hardware.HardwareBuffer;
 import android.os.Build;
 import android.os.IBinder;
+import android.os.OutcomeReceiver;
 
 import androidx.annotation.RequiresApi;
 
@@ -15,6 +16,9 @@ import com.rayworks.droidcast.wrapper.DisplayControl;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by seanzhou on 3/14/17.
@@ -23,6 +27,12 @@ import java.lang.reflect.Method;
 public final class ScreenCaptorUtils {
 
     private static final String METHOD_SCREENSHOT = "screenshot";
+
+    /** Default logical display id ({@code Display.DEFAULT_DISPLAY}). */
+    private static final int DEFAULT_DISPLAY_ID = 0;
+
+    /** Max time to block waiting for the asynchronous readback capture (Android 17+). */
+    private static final long SCREENSHOT_TIMEOUT_SECONDS = 5;
 
     private static final Class<?> clazz;
     private static Method getBuiltInDisplayMethod;
@@ -54,37 +64,21 @@ public final class ScreenCaptorUtils {
 
             int sdkInt = Build.VERSION.SDK_INT;
             if (sdkInt >= Build.VERSION_CODES.S) {
-                // create the DisplayCaptureArgs object by DisplayCaptureArgs$Builder.build()
-                Class<?> argsClass;
-                Class<?> innerClass;
-                if (sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    argsClass = Class.forName("android.window.ScreenCapture$DisplayCaptureArgs");
-                    innerClass = Class.forName("android.window.ScreenCapture$DisplayCaptureArgs$Builder");
-                } else {
-                    argsClass = Class.forName("android.view.SurfaceControl$DisplayCaptureArgs");
-                    innerClass = Class.forName("android.view.SurfaceControl$DisplayCaptureArgs$Builder");
-                }
-
-                Method setSzMethod = innerClass.getDeclaredMethod("setSize", int.class, int.class);
-                Method buildMethod = innerClass.getDeclaredMethod("build");
-
-                Constructor<?> ctor = innerClass.getDeclaredConstructor(IBinder.class);
-                Object builder = ctor.newInstance(getBuiltInDisplay());
-                setSzMethod.invoke(builder, w, h);
-                Object args = buildMethod.invoke(builder);
-
-                // call hidden method "ScreenshotHardwareBuffer captureDisplay(DisplayCaptureArgs captureArgs)"
-                Method captureDisplay = clazz.getDeclaredMethod("captureDisplay", argsClass);
-                Object hdBuffer = captureDisplay.invoke(null, args);
-
-                Class<?> hdBufferClass = hdBuffer.getClass();
-                ColorSpace colorSpace = (ColorSpace) hdBufferClass.getDeclaredMethod("getColorSpace").invoke(hdBuffer);
-
-                try (HardwareBuffer hardwareBuffer =
-                             (HardwareBuffer) hdBufferClass.getDeclaredMethod("getHardwareBuffer").invoke(hdBuffer)) {
-                    bitmap = Bitmap.wrapHardwareBuffer(hardwareBuffer, colorSpace);
-                } catch (Exception e) {
-                    e.printStackTrace();
+                try {
+                    // Android 12 (S) .. Android 16: DisplayCaptureArgs + captureDisplay(...)
+                    bitmap = captureViaDisplayCaptureArgs(w, h);
+                } catch (ClassNotFoundException | NoSuchMethodException e) {
+                    // The legacy DisplayCaptureArgs / captureDisplay hidden API was removed on
+                    // Android 16 QPR2 / Android 17+, where android.window.ScreenCapture was rewritten
+                    // around ScreenCaptureParams + ScreenCaptureResult and an async capture() call.
+                    // (This is the "android.window.ScreenCapture$DisplayCaptureArgs" ClassNotFoundException.)
+                    if (sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                        System.err.println(
+                                ">>> legacy captureDisplay unavailable, trying readback API : " + e);
+                        bitmap = captureViaReadback();
+                    } else {
+                        throw e;
+                    }
                 }
             } else if (sdkInt >= Build.VERSION_CODES.P) { // Pie+
                 declaredMethod =
@@ -112,6 +106,132 @@ public final class ScreenCaptorUtils {
         }
 
         return bitmap;
+    }
+
+    /**
+     * Legacy capture path used from Android 12 (S) up to Android 16: build a {@code
+     * DisplayCaptureArgs} and invoke the hidden synchronous {@code captureDisplay(DisplayCaptureArgs)},
+     * which returns a {@code ScreenshotHardwareBuffer}.
+     *
+     * <p>Throws {@link ClassNotFoundException} / {@link NoSuchMethodException} when this hidden API is
+     * absent (e.g. Android 16 QPR2 / Android 17+), signalling the caller to fall back to
+     * {@link #captureViaReadback()}.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.S)
+    private static Bitmap captureViaDisplayCaptureArgs(int w, int h)
+            throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
+            InstantiationException, InvocationTargetException {
+        // create the DisplayCaptureArgs object by DisplayCaptureArgs$Builder.build()
+        Class<?> argsClass;
+        Class<?> innerClass;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            argsClass = Class.forName("android.window.ScreenCapture$DisplayCaptureArgs");
+            innerClass = Class.forName("android.window.ScreenCapture$DisplayCaptureArgs$Builder");
+        } else {
+            argsClass = Class.forName("android.view.SurfaceControl$DisplayCaptureArgs");
+            innerClass = Class.forName("android.view.SurfaceControl$DisplayCaptureArgs$Builder");
+        }
+
+        Method setSzMethod = innerClass.getDeclaredMethod("setSize", int.class, int.class);
+        Method buildMethod = innerClass.getDeclaredMethod("build");
+
+        Constructor<?> ctor = innerClass.getDeclaredConstructor(IBinder.class);
+        Object builder = ctor.newInstance(getBuiltInDisplay());
+        setSzMethod.invoke(builder, w, h);
+        Object args = buildMethod.invoke(builder);
+
+        // call hidden method "ScreenshotHardwareBuffer captureDisplay(DisplayCaptureArgs captureArgs)"
+        Method captureDisplay = clazz.getDeclaredMethod("captureDisplay", argsClass);
+        Object hdBuffer = captureDisplay.invoke(null, args);
+        if (hdBuffer == null) {
+            return null;
+        }
+
+        Class<?> hdBufferClass = hdBuffer.getClass();
+        ColorSpace colorSpace =
+                (ColorSpace) hdBufferClass.getDeclaredMethod("getColorSpace").invoke(hdBuffer);
+        return wrapScreenshotBuffer(
+                hdBufferClass.getDeclaredMethod("getHardwareBuffer").invoke(hdBuffer), colorSpace);
+    }
+
+    /**
+     * Capture path for Android 16 QPR2 / Android 17+, where {@code android.window.ScreenCapture} was
+     * rewritten as an async, {@code IWindowManager}-backed API:
+     *
+     * <pre>
+     *   ScreenCaptureParams params = new ScreenCaptureParams.Builder(displayId).build();
+     *   ScreenCapture.capture(params, executor, OutcomeReceiver&lt;ScreenCaptureResult, Exception&gt;);
+     *   result.getHardwareBuffer(); result.getColorSpace();
+     * </pre>
+     *
+     * The callback is bridged to a synchronous result via a {@link CountDownLatch}.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private static Bitmap captureViaReadback()
+            throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
+            InstantiationException, InvocationTargetException {
+        Class<?> screenCaptureClass = Class.forName("android.window.ScreenCapture");
+        Class<?> paramsClass = Class.forName("android.window.ScreenCapture$ScreenCaptureParams");
+        Class<?> builderClass =
+                Class.forName("android.window.ScreenCapture$ScreenCaptureParams$Builder");
+        Class<?> resultClass = Class.forName("android.window.ScreenCapture$ScreenCaptureResult");
+
+        // ScreenCaptureParams.Builder(int displayId).build()
+        Constructor<?> builderCtor = builderClass.getConstructor(int.class);
+        Object builder = builderCtor.newInstance(DEFAULT_DISPLAY_ID);
+        Object params = builderClass.getMethod("build").invoke(builder);
+
+        final Object[] resultRef = new Object[1];
+        final CountDownLatch latch = new CountDownLatch(1);
+        OutcomeReceiver<Object, Throwable> receiver =
+                new OutcomeReceiver<Object, Throwable>() {
+                    @Override
+                    public void onResult(Object result) {
+                        resultRef[0] = result;
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onError(Throwable error) {
+                        System.err.println(">>> readback screen capture failed : " + error);
+                        latch.countDown();
+                    }
+                };
+
+        // Run the callback inline on the invoking (binder) thread; the latch does the synchronising.
+        Executor executor = Runnable::run;
+        Method captureMethod =
+                screenCaptureClass.getMethod(
+                        "capture", paramsClass, Executor.class, OutcomeReceiver.class);
+        captureMethod.invoke(null, params, executor, receiver);
+
+        try {
+            if (!latch.await(SCREENSHOT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                System.err.println(">>> timed out waiting for readback screen capture");
+                return null;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+
+        Object result = resultRef[0];
+        if (result == null) {
+            return null;
+        }
+
+        ColorSpace colorSpace =
+                (ColorSpace) resultClass.getMethod("getColorSpace").invoke(result);
+        return wrapScreenshotBuffer(
+                resultClass.getMethod("getHardwareBuffer").invoke(result), colorSpace);
+    }
+
+    /** Wraps a reflectively obtained {@link HardwareBuffer} into a {@link Bitmap}. */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static Bitmap wrapScreenshotBuffer(Object hardwareBufferObj, ColorSpace colorSpace) {
+        try (HardwareBuffer hardwareBuffer = (HardwareBuffer) hardwareBufferObj) {
+            return Bitmap.wrapHardwareBuffer(hardwareBuffer, colorSpace);
+        }
     }
 
     private static Method getGetBuiltInDisplayMethod() throws NoSuchMethodException {

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.0.21'
     repositories {
         mavenCentral()
         google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Problem

On Android 16 QPR2 / Android 17+, `android.window.ScreenCapture` was rewritten: the synchronous `DisplayCaptureArgs` + `captureDisplay(...)` hidden API was **removed** in favour of an async, `IWindowManager`-backed API (`ScreenCaptureParams` → `capture(params, Executor, OutcomeReceiver)` → `ScreenCaptureResult`).

As a result, `ScreenCaptorUtils.screenshot()` crashes with:

```
java.lang.ClassNotFoundException: android.window.ScreenCapture$DisplayCaptureArgs
    at com.rayworks.droidcast.ScreenCaptorUtils.screenshot(ScreenCaptorUtils.java:61)
```

(Stable Android 14–16 still ship the old class, so the existing path keeps working there.)

## Changes

**`ScreenCaptorUtils.java` — fallback chain on Android 12+:**
1. Try the legacy `DisplayCaptureArgs` / `captureDisplay(...)` path (Android 12–16).
2. On `ClassNotFoundException` / `NoSuchMethodException`, fall back to the new readback API via reflection — build `ScreenCaptureParams.Builder(displayId)`, call `ScreenCapture.capture(...)` with a direct `Executor`, and bridge the async `OutcomeReceiver` callback to a synchronous result with a `CountDownLatch` (5s timeout), then wrap `ScreenCaptureResult.getHardwareBuffer()/getColorSpace()` into a `Bitmap`.

The new path keys on an `int displayId` instead of an `IBinder` token, so it also avoids the `DisplayControl` bootstrap on newer OS.

**Build toolchain** (to compile against Android 16 / API 36):
- `compileSdk` / `targetSdk` 34 → 36
- AGP 8.6.0 → 8.9.1
- Gradle 8.7 → 8.11.1
- Kotlin 1.9.23 → 2.0.21

## Verification

- Toolchain compatibility confirmed (Gradle configures cleanly with the new AGP/Gradle/Kotlin).
- `ScreenCaptorUtils.java` compiles against `android-36/android.jar`.
- ⚠️ The new readback path has **not** been verified on real Android 16 QPR2 / 17 hardware. Watch logcat if the screenshot comes back empty:
  - The new API is `@FlaggedApi(FLAG_READBACK_SCREENSHOT)` — if that SurfaceFlinger flag is off, `capture()` may fail (timeout / failure log).
  - It requires `READ_FRAME_BUFFER` via WindowManager; a missing permission surfaces as a `SecurityException` in `onError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced screen capture behavior on newer Android versions, improving reliability with better handling of capture timing and fallbacks.
- **Bug Fixes**
  - Improved screenshot capture robustness when certain platform capture methods aren’t available.
- **Chores**
  - Updated Android and build toolchain versions, including the app’s compile/target SDK, Kotlin/Android Gradle plugin, and Gradle wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->